### PR TITLE
Modified Network Connectivity Internal Range terraform config to support exclude CIDR ranges feature.

### DIFF
--- a/mmv1/products/networkconnectivity/InternalRange.yaml
+++ b/mmv1/products/networkconnectivity/InternalRange.yaml
@@ -130,6 +130,13 @@ properties:
       If not set, defaults to the "10.0.0.0/8" address space. This can be used to search in other rfc-1918 address spaces like "172.16.0.0/12" and "192.168.0.0/16" or non-rfc-1918 address spaces used in the VPC.
     item_type:
       type: String
+  - name: 'excludeCidrRanges'
+    type: Array
+    description: |
+      Optional. List of IP CIDR ranges to be excluded. Resulting reserved Internal Range will not overlap with any CIDR blocks mentioned in this list.
+      Only IPv4 CIDR ranges are supported.
+    item_type:
+      type: String
   - name: 'users'
     type: Array
     description: |

--- a/mmv1/templates/terraform/examples/network_connectivity_internal_ranges_exclude_cidr.tf.tmpl
+++ b/mmv1/templates/terraform/examples/network_connectivity_internal_ranges_exclude_cidr.tf.tmpl
@@ -1,0 +1,23 @@
+resource "google_network_connectivity_internal_range" "{{$.PrimaryResourceId}}" {
+  name    = "{{index $.Vars "internal_range_name"}}"
+  description = "Test internal range"
+  network = google_compute_network.default.self_link
+  
+  prefix_length = 24
+  target_cidr_range = [
+    "10.4.0.0/16"
+  ]
+  exclude_cidr_ranges = [
+    "10.5.0.0/24",
+    "10.4.1.0/24",
+    "10.4.0.0/24",
+    "10.4.12.0/24",
+	"10.4.32.0/24",
+	"10.6.0.0/24",
+  ]
+}
+
+resource "google_compute_network" "default" {
+  name                    = "{{index $.Vars "network_name"}}"
+  auto_create_subnetworks = false
+}

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_internal_range_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_internal_range_test.go
@@ -200,3 +200,83 @@ resource "google_compute_network" "default" {
 }
 `, context)
 }
+
+func TestAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesExcludeCIDRExample_full(t *testing.T) {
+	t.Parallel()
+
+	context := map[string]interface{}{
+		"random_suffix": acctest.RandString(t, 10),
+	}
+
+	resourceName := "google_network_connectivity_internal_range.default"
+
+	acctest.VcrTest(t, resource.TestCase{
+		PreCheck:                 func() { acctest.AccTestPreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5ProviderFactories(t),
+		CheckDestroy:             testAccCheckNetworkConnectivityInternalRangeDestroyProducer(t),
+		Steps: []resource.TestStep{
+			{
+				Config: testAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesExcludeCIDRExample_full(context),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						resourceName, "description", "Test internal range exclude CIDR"),
+					resource.TestCheckResourceAttr(
+						resourceName, "target_cidr_range.0", "10.4.0.0/16"),
+					resource.TestCheckResourceAttr(
+						resourceName, "target_cidr_range.1", "10.5.0.0/16"),
+					resource.TestCheckResourceAttr(
+						resourceName, "prefix_length", "24"),
+					resource.TestCheckResourceAttr(
+						resourceName, "exclude_cidr_ranges.#", "6"),
+					resource.TestCheckResourceAttr(
+						resourceName, "exclude_cidr_ranges.0", "10.5.0.0/24"),
+					resource.TestCheckResourceAttr(
+						resourceName, "exclude_cidr_ranges.1", "10.4.1.0/24"),
+					resource.TestCheckResourceAttr(
+						resourceName, "exclude_cidr_ranges.2", "10.4.0.0/24"),
+					resource.TestCheckResourceAttr(
+						resourceName, "exclude_cidr_ranges.3", "10.4.12.0/24"),
+					resource.TestCheckResourceAttr(
+						resourceName, "exclude_cidr_ranges.4", "10.4.32.0/24"),
+					resource.TestCheckResourceAttr(
+						resourceName, "exclude_cidr_ranges.5", "10.6.0.0/24"),
+				),
+			},
+			{
+				ResourceName:            resourceName,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"name", "network", "labels", "terraform_labels"},
+			},
+		},
+	})
+}
+
+func testAccNetworkConnectivityInternalRange_networkConnectivityInternalRangesExcludeCIDRExample_full(context map[string]interface{}) string {
+	return acctest.Nprintf(`
+resource "google_network_connectivity_internal_range" "default" {
+  name    = "basic%{random_suffix}"
+  description = "Test internal range exclude CIDR"
+  network = google_compute_network.default.name
+
+  prefix_length = 24
+  target_cidr_range = [
+    "10.4.0.0/16",
+	"10.5.0.0/16",
+  ]
+  exclude_cidr_ranges = [
+    "10.5.0.0/24",
+    "10.4.1.0/24",
+    "10.4.0.0/24",
+    "10.4.12.0/24",
+	"10.4.32.0/24",
+	"10.6.0.0/24",
+  ]
+}
+
+resource "google_compute_network" "default" {
+  name                    = "tf-test-internal-ranges%{random_suffix}"
+  auto_create_subnetworks = false
+}
+`, context)
+}

--- a/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_internal_range_test.go
+++ b/mmv1/third_party/terraform/services/networkconnectivity/resource_network_connectivity_internal_range_test.go
@@ -272,6 +272,8 @@ resource "google_network_connectivity_internal_range" "default" {
 	"10.4.32.0/24",
 	"10.6.0.0/24",
   ]
+  usage   = "FOR_VPC"
+  peering = "FOR_SELF"
 }
 
 resource "google_compute_network" "default" {


### PR DESCRIPTION
This PR aims to modify the Internal Range Terraform support as follows:

1. Add a new field available to the Internal Range resource called excludeCidrRanges.
2. Add a template file showing how the feature is used.
3. Added acceptance test for the newly added feature.

Note that:
- The feature is not fully rolled out in v1.

```enhancement
networkconnectivity: added `excludeCidrRanges` field to `google_network_connectivity_internal_range` resource
```
